### PR TITLE
fixes deprecated workspace

### DIFF
--- a/keymaps/open-in-gitx.cson
+++ b/keymaps/open-in-gitx.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'cmd-ctrl-x': 'open-in-gitx:open'

--- a/lib/open-in-gitx.coffee
+++ b/lib/open-in-gitx.coffee
@@ -2,7 +2,7 @@ exec = require("child_process").exec
 
 module.exports =
   activate: (state) ->
-    atom.workspaceView.command "open-in-gitx:open", => @openApp()
+    atom.commands.add 'atom-workspace', 'open-in-gitx:open', => @openApp()
 
   openApp: ->
     path = atom.project?.getPath()


### PR DESCRIPTION
Atom has changed how to set key binds for workspaces. These are the necessary changes to make it work with the new approach.
