### PR TITLE
open gitx based in the current repository

### DIFF
--- a/lib/open-in-gitx.coffee
+++ b/lib/open-in-gitx.coffee
@@ -5,5 +5,34 @@ module.exports =
     atom.workspaceView.command "open-in-gitx:open", => @openApp()
 
   openApp: ->
-    path = atom.project?.getPath()
-    exec "open -a GitX.app #{path}" if path?
+    getRepo().then (repo) ->
+      exec "open -a GitX.app #{repo.workingDirectory}" if repo?
+
+# Get the repository of the current file or project if no current file
+# Returns a {Promise} that resolves to a repository like object
+getRepo = ->
+  new Promise (resolve, reject) ->
+    getRepoForCurrentFile().then (repo) -> resolve(repo)
+    .catch (e) ->
+      repos = atom.project.getRepositories().filter (r) -> r?
+      if repos.length is 0
+        console.log "No repos found"
+        reolve()
+      else
+        resolve(repos[0].repo)
+
+getRepoForCurrentFile = ->
+  new Promise (resolve, reject) ->
+    project = atom.project
+    path = atom.workspace.getActiveTextEditor()?.getPath()
+    directory = project.getDirectories().filter((d) -> d.contains(path))[0]
+    if directory?
+      project.repositoryForDirectory(directory).then (repo) ->
+        submodule = repo.repo.submoduleForPath(path)
+        if submodule?
+          resolve(submodule.repo)
+        else resolve(repo.repo)
+      .catch (e) ->
+        reject(e)
+    else
+      reject "no current file"


### PR DESCRIPTION
This code is based in the implementation used by git-plus to get the current repository.

This feature is very handy on using multiple projects (root folders) in the same workspace.
